### PR TITLE
Make improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-CFLAGS  = -Wall -I/usr/local/include
-LDFLAGS = -L/usr/local/lib/ -lssh2
+CFLAGS      = -Wall -I/usr/local/include
+LDFLAGS     = -L/usr/local/lib/ -lssh2
+
+prefix      = /usr/local
+exec_prefix = $(prefix)
+bindir      = $(exec_prefix)/bin
 
 all: beleth
 
@@ -12,7 +16,14 @@ lists.o: lists.c
 
 ssh.o: ssh.c
 
+install:
+	install -d $(DESTDIR)$(bindir)
+	install -m 0755 beleth $(DESTDIR)$(bindir)
+
+uninstall:
+	-rm $(DESTDIR)$(bindir)/beleth
+
 clean:
 	-rm *.o beleth
 
-.PHONY: clean
+.PHONY: clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-CFLAGS+=	-Wall -I/usr/local/include
-LDFLAGS+=	-L/usr/local/lib/ -lssh2
+CFLAGS  = -Wall -I/usr/local/include
+LDFLAGS = -L/usr/local/lib/ -lssh2
 
 all: beleth
 
 beleth: beleth.o lists.o ssh.o
-	$(CC) beleth.o lists.o ssh.o $(LDFLAGS) -o beleth
+	$(CC) beleth.o lists.o ssh.o $(LDFLAGS) -o $@
 
 beleth.o: beleth.c
 
@@ -13,4 +13,6 @@ lists.o: lists.c
 ssh.o: ssh.c
 
 clean:
-	rm *.o beleth
+	-rm *.o beleth
+
+.PHONY: clean


### PR DESCRIPTION
According to the GNU make manual user variables CFLAGS, and LDFLAGS are
defined as an empty strings.
$@ target, happens to be portable and useful
- do not care about exit status
  Using .PHONY ensures that make won't go looking for nonexistent product files
  named after these targets.
